### PR TITLE
Fixes for Behat 3.0 and some additional features

### DIFF
--- a/config.php.dist
+++ b/config.php.dist
@@ -21,3 +21,16 @@ $app->configureMysql('localhost', 'behat_launcher', 'root', '');
 //         ->setDefault('chrome')
 //         ->setChoices(array('firefox' => 'Mozilla Firefox', 'chrome' => 'Google Chrome'))
 //     ->endProperty()
+
+//// Use specific behat.yml file
+//// Use profile parameter
+//// Use *.feature files filter based on specified tag
+//$app->createProject('INT: [Smoke - Chrome]', '/var/www/bros')
+//    ->setBehatYmlFile('behat_Chrome.yml')
+//    // behat --profile int
+//    ->setProfile('int')
+//    ->setTags('@smoke')
+//    // filter .feature files that contain @smoke tag
+//    // (otherwise behat raises error that no scenario was found)
+//    ->setFileFilter('@smoke')
+//    ->setFeaturesPath('features/all');

--- a/src/Alex/BehatLauncher/Behat/FeatureFinder.php
+++ b/src/Alex/BehatLauncher/Behat/FeatureFinder.php
@@ -6,13 +6,25 @@ use Symfony\Component\Finder\Finder;
 
 class FeatureFinder
 {
-    public function findFeatures($path)
+    public function findFeatures($path, $contentFilters = null)
     {
-        $finder = Finder::create()
-            ->sortByName()
-            ->in($path)
-            ->name('*.feature')
-        ;
+        if ($contentFilters == null)
+        {
+            $finder = Finder::create()
+                ->sortByName()
+                ->in($path)
+                ->name('*.feature')
+            ;
+        }
+        else
+        {
+            $finder = Finder::create()
+                ->sortByName()
+                ->in($path)
+                ->name('*.feature')
+                ->contains($contentFilters)
+            ;
+        }
 
         $result = new FeatureDirectory('');
 

--- a/src/Alex/BehatLauncher/Behat/Project.php
+++ b/src/Alex/BehatLauncher/Behat/Project.php
@@ -50,6 +50,26 @@ class Project implements NormalizableInterface
     private $runnerCount = 1;
 
     /**
+     * @var string
+     */
+    private $behatYmlFile = 'behat.yml';
+
+    /**
+     * @var string
+     */
+    private $profile = 'default';
+
+    /**
+     * @var string
+     */
+    private $tags = '';
+
+    /**
+     * @var string
+     */
+    private $fileFilter = null;
+
+    /**
      * Creates a new Behat Launcher project, to execute runs on it.
      *
      * @param string $name project name
@@ -109,8 +129,8 @@ class Project implements NormalizableInterface
      */
     public function getConfig(array $values = array())
     {
-        if (file_exists($file = $this->path.'/behat.yml')) {
-            $content = Yaml::parse($file);
+        if (file_exists($file = $this->path . DIRECTORY_SEPARATOR . $this->behatYmlFile)) {
+            $content = Yaml::parse(file_get_contents($file));
         } else {
             $content = array();
         }
@@ -139,7 +159,7 @@ class Project implements NormalizableInterface
 
         $finder = new FeatureFinder();
 
-        return $finder->findFeatures($path);
+        return $finder->findFeatures($path, $this->getFileFilter());
     }
 
     /**
@@ -354,4 +374,99 @@ class Project implements NormalizableInterface
 
         return $this;
     }
+
+    /**
+     * Set behat.yml file
+     *
+     * @param $behatYmlFile
+     * @return Project
+     */
+    public function setBehatYmlFile($behatYmlFile)
+    {
+        $this->behatYmlFile = $behatYmlFile;
+
+        return $this;
+    }
+
+    /**
+     * Returns the current behat.yml file
+     *
+     * @return string
+     */
+    public function getBehatYmlFile()
+    {
+        return $this->behatYmlFile;
+    }
+
+    /**
+     * Set the profile to be sent to behat command line
+     *
+     * @param $profile
+     * @return $this
+     */
+    public function setProfile($profile)
+    {
+        $this->profile = $profile;
+
+        return $this;
+    }
+
+    /**
+     * Get the current set profile
+     *
+     * @return string
+     */
+    public function getProfile()
+    {
+        return $this->profile;
+    }
+
+    /**
+     * Get the current set tags
+     *
+     * @return string
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * Set the tags to be sent to behat command line
+     *
+     * @param string $tags
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * Get the current set file filters
+     *
+     * @return string
+     */
+    public function getFileFilter()
+    {
+        return $this->fileFilter;
+    }
+
+    /**
+     * Set the filters to be used on .feature files (file contains ...)
+     * used in \Alex\BehatLauncher\Behat\FeatureFinder::findFeatures()
+     * http://symfony.com/doc/current/components/finder.html#file-contents
+     *
+     * @param string $fileFilter
+     * @return $this
+     */
+    public function setFileFilter($fileFilter)
+    {
+        $this->fileFilter = $fileFilter;
+
+        return $this;
+    }
+
 }

--- a/src/Alex/BehatLauncher/Behat/RunUnit.php
+++ b/src/Alex/BehatLauncher/Behat/RunUnit.php
@@ -150,7 +150,12 @@ class RunUnit implements NormalizableInterface
         $pb->add('-f')->add(implode(',', $argFormats));
         $pb->add('--out')->add(implode(',', $argOutputs));
 
-        $pb->add('--ansi');
+        $pb->add('--colors');
+
+        $pb->add('--profile')->add($project->getProfile());
+
+        // add tags parameter only if set (empty by default)
+        $project->getTags() !== '' ? $pb->add('--tags')->add($project->getTags()) : null;
 
         $this->process = $pb->getProcess();
 

--- a/src/Alex/BehatLauncher/Controller/FrontendController.php
+++ b/src/Alex/BehatLauncher/Controller/FrontendController.php
@@ -33,6 +33,6 @@ class FrontendController extends Controller
         if (!in_array($locale, array('en', 'fr'))) {
             $locale = 'en';
         }
-        return $this->serialize(Yaml::parse(__DIR__.'/../Resources/locales/'.$locale.'.yml'));
+        return $this->serialize(Yaml::parse(file_get_contents(__DIR__.'/../Resources/locales/'.$locale.'.yml')));
     }
 }

--- a/src/Alex/BehatLauncher/Controller/OutputFileController.php
+++ b/src/Alex/BehatLauncher/Controller/OutputFileController.php
@@ -24,8 +24,6 @@ class OutputFileController extends Controller
             $content = $converter->convert($content);
             $template = 'outputFile_text.html.twig';
 
-            // Daniel Candrea: insert screenshots
-
             // extract screenshots messages
             preg_match_all('#Screenshot at: (.*)#', $content, $screenshots, PREG_OFFSET_CAPTURE);
             foreach ($screenshots[0] as $screenshot)


### PR DESCRIPTION
Hello,

Great work, I really appreciate it!
I've been using the tool for the past 2 months and I'm very satisfied.
I've added a couple of extra features / small fixes and I want to make them public, maybe there are others that might find them useful.

Changes:
### Feature files can now be filtered based on content

My story: I've created a @smoke tag and used it only for some scenarios. There were files which contained no such tag, therefore on execution an error would have been thrown (that no scenario was found). Now the list of .feature files displays only the files containing @smoke tag. This is just an example, you can use any text as filter.

Example of usage:

```
$app->createProject('INT: [Smoke - Chrome]', '/var/www/bros')
    ->setFileFilter('@smoke');
```
### Added new project properties (optional):
- behatYmlFile: specify behat.yml file other than default (--config)
- profile: specify a profile parameter for behat command line (--profile)
- tags: specify a tag parameter for behat command line (--tags)
- fileFilter: specify a filter for feature files (explained above)

Example of usage:

```
$app->createProject('INT: [Smoke - Chrome]', '/var/www/bros')
    ->setBehatYmlFile('behat_Chrome.yml')
    // behat --profile int
    ->setProfile('int')
    ->setTags('@smoke')
    // filter .feature files that contain @smoke tag
    // (otherwise behat raises error that no scenario was found)
    ->setFileFilter('@smoke');
```
### Insert screenshots into output window

My story: after each step, if an error occurs I capture a screenshot of the browser and I print a message with the path:

```
    /**
     * Capture screenshot after a step has failed (valid only for webdriver)
     *
     * @AfterStep
     * @param AfterStepScope $scope
     */
    public function afterStep(AfterStepScope $scope)
    {
        if (99 === $scope->getTestResult()->getResultCode())
        {
            $this->takeScreenshot();
        }
    }
```

```
   /**
     * Capture screenshot of the browser opened by Selenium
     */
    private function takeScreenshot()
    {
        $driver = $this->getSession()->getDriver();
        if ($driver instanceof Selenium2Driver)
        {   
                $fileName = date('Y-m-d_H-i-s') . '_' . uniqid() . '.png';
                $filePath = getcwd() . DIRECTORY_SEPARATOR . 'screenshots';

                // create folder if not already existing
                if (!file_exists($filePath))
                {
                    mkdir($filePath, 0777, true);
                }

                $this->saveScreenshot($fileName, $filePath);
                print('Screenshot at: ' . $filePath . DIRECTORY_SEPARATOR . $fileName);
        }
    }
```

Now the text displayed in the output window is parsed and if such messages are found, they are replaced with the actual images so they can be seen directly
(tested on Windows and Mac OS X)

```
    public function showAction($id)
    {
        $path = $this->getRunStorage()->getOutputFilePath($id);
        $content = file_get_contents($path);

        if (false !== strpos($content, '<html')) {
            $template = 'outputFile_html.html.twig';
        } else {
            $converter = new AnsiToHtmlConverter();
            $content = $converter->convert($content);
            $template = 'outputFile_text.html.twig';

            // extract screenshots messages
            preg_match_all('#Screenshot at: (.*)#', $content, $screenshots, PREG_OFFSET_CAPTURE);
            foreach ($screenshots[0] as $screenshot)
            {
                // extract screenshot path
                $screenshotPath = str_replace("Screenshot at: ", "", $screenshot[0]);
                $image = $this->generateImage(trim($screenshotPath));

                // add <img> tag
                $content = str_replace("Screenshot at: " . $screenshotPath, '<a href="file:///' . $screenshotPath . '">' . $screenshotPath . '</a>'
                    . '<p><img src="data:image/png;base64,' . $image . ' "/>', $content);

                $image = null;
                $screenshotPath = null;
            }
        }

        return $this->render($template, array(
            'content' => $content
        ));
    }
```

![output_screenshot](https://cloud.githubusercontent.com/assets/3902324/8794575/8a56b4d0-2f8d-11e5-8e65-1849bc6a6bcb.png)
### Fixes:
1. Replaced behat command line parameter '--ansi' with '--colors' (for Behat 3.0) 
2. There was a change in Yaml::parse() method signature
